### PR TITLE
Fix My Presets showing empty: query the view, not the base table

### DIFF
--- a/platform/src/components/MyPresets.tsx
+++ b/platform/src/components/MyPresets.tsx
@@ -8,23 +8,33 @@ const MyPresets = () => {
   const userID = session?.user?.id;
 
   useEffect(() => {
-    if (userID) {
-      const fetchPresets = async () => {
-        const { data, error } = await supabase
-          .from("preset")
-          .select("*")
-          .eq("user_id", userID);
-        if (!error && data) setPresets(data);
-      };
-      fetchPresets();
-    }
+    const db = supabase;
+    if (!db || !userID) return;
+    const fetchPresets = async () => {
+      // Query the view, not the base table — `user_id` lives on
+      // preset_with_username (joined with users), not on preset itself.
+      const { data, error } = await db
+        .from("preset_with_username")
+        .select("*")
+        .eq("user_id", userID);
+      if (error) {
+        console.error("MyPresets fetch failed:", error);
+        return;
+      }
+      setPresets(data ?? []);
+    };
+    fetchPresets();
   }, [userID]);
 
   const handleDelete = async (id: number) => {
+    if (!supabase) return;
+    // Delete from the base table — views are not deletable.
     const { error } = await supabase.from("preset").delete().eq("id", id);
-    if (!error) {
-      setPresets(prev => prev.filter((p) => p.id !== id));
+    if (error) {
+      console.error("MyPresets delete failed:", error);
+      return;
     }
+    setPresets(prev => prev.filter((p) => p.id !== id));
   };
 
   return (


### PR DESCRIPTION
## Summary

- Switch MyPresets SELECT from \`preset\` (base table) to \`preset_with_username\` (view)
- Surface fetch/delete errors via \`console.error\` instead of swallowing them
- Null-guard \`supabase\` for guest-mode safety

## The bug

After Gladys's recent fix (bc9a793), the My Presets page rendered \"No presets found\" even for users who had created presets. No console errors, no visual feedback — just empty.

## Root cause

Gladys's commit correctly changed the filter from \`author = email\` to \`user_id = UUID\`. That was the right direction. But the query still pointed at the raw \`preset\` table:

\`\`\`
.from(\"preset\")
.select(\"*\")
.eq(\"user_id\", userID)
\`\`\`

The base \`preset\` table has no \`user_id\` column. That column only exists on the \`preset_with_username\` **view**, which joins \`preset\` with the users table. The project had already migrated to this view pattern earlier — commit \`826ed22 \"Fix Explore page query to use preset_with_username view\"\` — and \`Profile.tsx:27-29\` uses it correctly.

Supabase was returning a \"column does not exist\" error on every fetch. But MyPresets swallowed it:

\`\`\`
if (!error && data) setPresets(data);
\`\`\`

No \`else\`, no log, no toast. The UI silently fell back to the empty state.

## The fix

1. **SELECT** now queries \`preset_with_username\` to match Profile's pattern.
2. **DELETE** still targets the base \`preset\` table by \`id\` — views aren't deletable, and DELETE doesn't need \`user_id\`.
3. **Errors** go to \`console.error\` so the next silent failure is loud.
4. **\`supabase\` is null-guarded** to match Profile/Explore and avoid a guest-mode crash.

## Evidence this is the right column

The only preset insert site in the repo (\`server_endpoint/addPreset/AddPreset.js:8-16\`) inserts \`{ name, tag, audiosource }\` — there is no \`user_id\` column on the base table at all. It only exists on the view.

## Test plan

- [ ] \`npm run dev\`, sign in as a user who has created presets
- [ ] Navigate to My Presets → presets should render with the real count in the header
- [ ] Click Remove on one → it disappears from the list and is deleted from the DB
- [ ] Sign in as a user with no presets → \"No presets found\" (correct empty state, not a silent error)
- [ ] Any errors now surface in the browser console