### PR TITLE
MyPresets: loading/signed-out states + query base table

### DIFF
--- a/platform/src/components/MyPresets.tsx
+++ b/platform/src/components/MyPresets.tsx
@@ -4,26 +4,30 @@ import { useEffect, useState } from "react";
 
 const MyPresets = () => {
   const [presets, setPresets] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
   const { session } = UserAuth();
   const userID = session?.user?.id;
 
   useEffect(() => {
-    const db = supabase;
-    if (!db || !userID) return;
-    const fetchPresets = async () => {
-      // Query the view, not the base table — `user_id` lives on
-      // preset_with_username (joined with users), not on preset itself.
-      const { data, error } = await db
-        .from("preset_with_username")
+    if (!supabase) return;
+    if (!userID) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    (async () => {
+      const { data, error } = await supabase
+        .from("preset")
         .select("*")
         .eq("user_id", userID);
       if (error) {
-        console.error("MyPresets fetch failed:", error);
-        return;
+        console.error("MyPresets fetch failed:", error, "userID=", userID);
+      } else {
+        console.log(`MyPresets: fetched ${data?.length ?? 0} for user ${userID}`);
+        setPresets(data ?? []);
       }
-      setPresets(data ?? []);
-    };
-    fetchPresets();
+      setLoading(false);
+    })();
   }, [userID]);
 
   const handleDelete = async (id: number) => {
@@ -49,7 +53,15 @@ const MyPresets = () => {
       </header>
 
       <div className="mage-stack mage-stack--lg">
-        {presets.length > 0 ? (
+        {loading ? (
+          <div className="mage-panel">
+            <p className="mage-preset-list__empty">Loading presets…</p>
+          </div>
+        ) : !userID ? (
+          <div className="mage-panel">
+            <p className="mage-preset-list__empty">Please sign in to see your presets.</p>
+          </div>
+        ) : presets.length > 0 ? (
           <ul className="mage-preset-list">
             {presets.map((p, index) => (
               <li key={p.id} className="mage-preset-item">


### PR DESCRIPTION
## Summary
- Verified via Supabase REST that `preset.user_id` exists — the previous "query the view instead" fix was based on a false premise. Both the view and the base table return the same rows.
- The persistent "No presets found" almost certainly means **you're signed in as an account with zero presets** (the DB only has rows for 2 user_ids). There was no loading state, so a signed-out or still-fetching render looked identical to genuinely empty.
- Switched back to `preset` (simpler, no view dependency), added a loading state, a signed-out state, and a console log of the fetched count + userID so you can tell which account you're on.

## Test plan
- [ ] Sign in → page shows "Loading presets…" then either the list or "No presets found."
- [ ] Signed out → shows "Please sign in to see your presets."
- [ ] Check devtools console for `MyPresets: fetched N for user <uuid>` to confirm your user_id.