### PR TITLE
Fix Player crash: disable Rollup tree-shaking for shader-park

### DIFF
--- a/platform/vite.config.ts
+++ b/platform/vite.config.ts
@@ -26,15 +26,39 @@ export default defineConfig({
     },
   },
   build: {
-    // shader-park (inside mage) builds GLSL via eval() on strings that
-    // reference identifiers like `input`, `sdBox`, `time`. esbuild's
-    // minifier mangles local variable names, which breaks those eval'd
-    // lookups — works in dev, ReferenceError in production build.
-    // terser with mangle:false preserves names but still removes dead code
-    // and whitespace, so the bundle stays small and shader-park survives.
+    // shader-park (inside mage) builds GLSL by running eval() on strings
+    // that reference identifiers like `input`, `sdBox`, `time` — those
+    // identifiers are defined as local functions inside sculptToGLSL.
+    //
+    // A bundler cannot see inside eval'd strings, so it thinks those
+    // locals are unused and either renames (mangle) or deletes (compress
+    // dead-code) them. Both break shader-park at runtime with
+    //   ReferenceError: input is not defined
+    // in the production build. Dev mode is fine because it skips minify.
+    //
+    // Fix: use terser with mangle OFF and compress's dead-code passes OFF
+    // so identifiers survive. Whitespace stripping and safe rewrites still
+    // run, so the bundle stays small enough for GitHub Pages.
+    // Rollup tree-shaking strips nested functions inside sculptToGLSL
+    // (input, input2D, test, noLighting, etc.) because their only callers
+    // live inside eval'd strings that the bundler cannot see. Without this,
+    // the production build crashes with ReferenceError: input is not defined
+    // on the Player page. Dev mode is unaffected because it skips bundling.
+    rollupOptions: {
+      treeshake: false,
+    },
+    // terser with mangle + compress's dead-code passes OFF so anything that
+    // survives tree-shake-off also survives minification. Identifiers are
+    // still referenced by name inside eval'd strings at runtime.
     minify: 'terser',
     terserOptions: {
       mangle: false,
+      compress: {
+        unused: false,
+        dead_code: false,
+        reduce_vars: false,
+        collapse_vars: false,
+      },
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## TL;DR

The Player page still crashes in production with \`ReferenceError: input is not defined\` even after PR #70. This PR fixes the real root cause.

## What PR #70 got wrong

PR #70 set \`terser\` with \`mangle: false\`, assuming the crash came from terser renaming variables. After the fix was deployed, the live bundle still crashed with the same error.

I investigated the deployed bundle and found that \`sculptToGLSL(userProvidedSrc)\` and \`generatedJSFuncsSource\` had fully preserved multi-character names — so terser was working as intended. But \`function input(name)\` was **completely missing** from the bundle. Not renamed. Gone.

## Real root cause

**Rollup's tree-shaking runs before terser** and strips nested function declarations it thinks are unreachable. Inside shader-park's \`sculptToGLSL\`, these helpers are declared as local functions:

- \`function test()\`
- \`function input(name)\`
- \`function input2D(name)\`
- \`function noLighting()\`
- \`function occlusion(amount)\`
- \`function getPixelCoord()\`

They are only called from inside an \`eval()\` string at runtime. Rollup cannot see through \`eval\`, decides the functions are unused, and removes them from the bundle. Dev mode is unaffected because Vite skips bundling and serves the source as-is.

Terser never had a chance to preserve identifiers that Rollup had already deleted.

## Evidence

I grepped the live production bundle at the time of the crash:

\`\`\`
function test(          -> -1  (missing)
function input(name     -> -1  (missing)
function input2D(       -> -1  (missing)
function getPixelCoord( -> -1  (missing)
function noLighting(    -> -1  (missing)
function occlusion(     -> -1  (missing)
\`\`\`

After this fix (\`rollupOptions.treeshake: false\`):

\`\`\`
function test(          -> PRESENT
function input(name     -> PRESENT
function input2D(       -> PRESENT
function getPixelCoord( -> PRESENT
function noLighting(    -> PRESENT
function occlusion(     -> PRESENT
\`\`\`

## Fix

1. **\`rollupOptions.treeshake: false\`** — nested helpers survive bundling. This is the critical change.
2. **terser \`compress.unused/dead_code/reduce_vars/collapse_vars: false\`** — anything that survives Rollup also survives the minifier's own DCE pass. Defense in depth. Retains the earlier \`mangle: false\` from PR #70.

## Cost

Bundle size goes from 18.8 MB unzipped to 22 MB unzipped. Gzipped grows from 11.4 MB to 11.8 MB. The extra ~3 MB is unreachable code that Rollup was correctly stripping for everything EXCEPT the shader-park helpers. Not worth fine-tuning; the proper fix later is to dynamic-import the engine so this whole chunk loads on demand.

## Test plan

- [ ] \`cd platform && npm run build\` completes (\`rollupOptions.treeshake: false\` adds a few seconds)
- [ ] \`npm run preview\`, open the Player page in a browser, confirm no \`ReferenceError: input is not defined\`
- [ ] Verify visuals actually render — earlier fixes built clean but still crashed at runtime, so a pure build check is not enough
- [ ] \`npm run dev\` still works

## Follow-up

Bundle is now 22 MB. The right long-term fix is code-splitting the engine into its own async chunk via \`React.lazy\`/dynamic \`import()\`. Out of scope for this PR — the goal here is \"make Player work in production.\"