### PR TITLE
Profile: avatar upload + editable username

### DIFF
--- a/database/profile.sql
+++ b/database/profile.sql
@@ -1,0 +1,110 @@
+-- Profile table: one row per auth user, holds username + avatar.
+-- Idempotent: safe to re-run. Won't drop or overwrite existing data.
+
+create table if not exists profile (
+  user_id uuid primary key references auth.users (id) on update cascade on delete cascade,
+  username text,
+  avatar_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Backfill columns if the table existed with an older shape.
+alter table profile add column if not exists username   text;
+alter table profile add column if not exists avatar_url text;
+alter table profile add column if not exists created_at timestamptz not null default now();
+alter table profile add column if not exists updated_at timestamptz not null default now();
+
+-- Usernames should be unique (case-insensitive) when set.
+create unique index if not exists profile_username_unique
+  on profile (lower(username))
+  where username is not null;
+
+-- RLS: anyone can read (so usernames/avatars show up in preset lists),
+-- but users can only write their own row.
+alter table profile enable row level security;
+
+drop policy if exists "profile_public_read"    on profile;
+drop policy if exists "profile_insert_own"     on profile;
+drop policy if exists "profile_update_own"     on profile;
+
+create policy "profile_public_read"
+  on profile for select
+  using (true);
+
+create policy "profile_insert_own"
+  on profile for insert
+  with check (auth.uid() = user_id);
+
+create policy "profile_update_own"
+  on profile for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Auto-create a profile row on signup so every user has one.
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profile (user_id, username)
+  values (new.id, split_part(new.email, '@', 1))
+  on conflict (user_id) do nothing;
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- Backfill existing users who don't have a profile row yet.
+insert into public.profile (user_id, username)
+select u.id, split_part(u.email, '@', 1)
+from auth.users u
+left join public.profile p on p.user_id = u.id
+where p.user_id is null;
+
+
+-- ============================================================
+-- Storage bucket for avatars
+-- ============================================================
+
+insert into storage.buckets (id, name, public)
+values ('avatars', 'avatars', true)
+on conflict (id) do nothing;
+
+-- Public read for avatars, users can only write their own folder.
+-- Path convention: <user_id>/<filename>
+drop policy if exists "avatars_public_read"    on storage.objects;
+drop policy if exists "avatars_insert_own"     on storage.objects;
+drop policy if exists "avatars_update_own"     on storage.objects;
+drop policy if exists "avatars_delete_own"     on storage.objects;
+
+create policy "avatars_public_read"
+  on storage.objects for select
+  using (bucket_id = 'avatars');
+
+create policy "avatars_insert_own"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'avatars'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+create policy "avatars_update_own"
+  on storage.objects for update
+  using (
+    bucket_id = 'avatars'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+create policy "avatars_delete_own"
+  on storage.objects for delete
+  using (
+    bucket_id = 'avatars'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );

--- a/platform/src/components/Profile.tsx
+++ b/platform/src/components/Profile.tsx
@@ -1,40 +1,141 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { UserAuth } from "../context/AuthContext";
 import { supabase } from "../supabaseClient";
 
-type Preset = {
-  id: number;
-  name: string;
-  description?: string;
-  likes?: number;
-  username?: string;
+type ProfileRow = {
+  user_id: string;
+  username: string | null;
+  avatar_url: string | null;
 };
 
 const Profile = () => {
   const { session, signOut } = UserAuth();
-  const [presets, setPresets] = useState<Preset[]>([]);
-  const [loading, setLoading] = useState(true);
-
   const userId = session?.user?.id;
-  const email = session?.user?.email;
+  const email = session?.user?.email ?? "";
+  const createdAt = session?.user?.created_at;
+
+  const [profile, setProfile] = useState<ProfileRow | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [editingName, setEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!supabase || !userId) {
       setLoading(false);
       return;
     }
-    supabase
-      .from("preset_with_username")
-      .select("*")
-      .eq("user_id", userId)
-      .then(({ data, error }: { data: any; error: any }) => {
-        if (!error && data) setPresets(data);
-        setLoading(false);
-      });
-  }, [userId]);
+    let cancelled = false;
+    (async () => {
+      const { data, error } = await supabase
+        .from("profile")
+        .select("user_id, username, avatar_url")
+        .eq("user_id", userId)
+        .maybeSingle();
+      if (cancelled) return;
+      if (error) {
+        setError(error.message);
+      } else if (data) {
+        setProfile(data as ProfileRow);
+        setNameDraft((data as ProfileRow).username ?? "");
+      } else {
+        const fallback: ProfileRow = {
+          user_id: userId,
+          username: email ? email.split("@")[0] : null,
+          avatar_url: null,
+        };
+        setProfile(fallback);
+        setNameDraft(fallback.username ?? "");
+      }
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, email]);
 
-  const username = presets[0]?.username ?? email.split("@")[0];
-  const presetCount = presets.length;
+  const displayName =
+    profile?.username?.trim() || (email ? email.split("@")[0] : "guest");
+  const initial = (displayName[0] ?? "?").toUpperCase();
+  const memberSince = createdAt
+    ? new Date(createdAt).toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : "—";
+
+  const saveUsername = async () => {
+    if (!supabase || !userId) return;
+    const trimmed = nameDraft.trim();
+    if (!trimmed) {
+      setError("Username can't be empty.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    const { error } = await supabase
+      .from("profile")
+      .upsert(
+        { user_id: userId, username: trimmed },
+        { onConflict: "user_id" },
+      );
+    setSaving(false);
+    if (error) {
+      setError(error.message);
+      return;
+    }
+    setProfile((p) => (p ? { ...p, username: trimmed } : p));
+    setEditingName(false);
+  };
+
+  const onAvatarFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file || !supabase || !userId) return;
+    if (!file.type.startsWith("image/")) {
+      setError("Avatar must be an image.");
+      return;
+    }
+    if (file.size > 2 * 1024 * 1024) {
+      setError("Avatar must be under 2 MB.");
+      return;
+    }
+    setUploading(true);
+    setError(null);
+
+    const ext = file.name.split(".").pop()?.toLowerCase() || "png";
+    const path = `${userId}/avatar.${ext}`;
+
+    const { error: upErr } = await supabase.storage
+      .from("avatars")
+      .upload(path, file, { upsert: true, contentType: file.type });
+    if (upErr) {
+      setUploading(false);
+      setError(upErr.message);
+      return;
+    }
+
+    const { data: pub } = supabase.storage.from("avatars").getPublicUrl(path);
+    const cacheBusted = `${pub.publicUrl}?t=${Date.now()}`;
+
+    const { error: dbErr } = await supabase
+      .from("profile")
+      .upsert(
+        { user_id: userId, avatar_url: cacheBusted },
+        { onConflict: "user_id" },
+      );
+    setUploading(false);
+    if (dbErr) {
+      setError(dbErr.message);
+      return;
+    }
+    setProfile((p) => (p ? { ...p, avatar_url: cacheBusted } : p));
+  };
 
   return (
     <div className="mage-page">
@@ -46,54 +147,104 @@ const Profile = () => {
           </p>
           <h1 className="mage-title">Account</h1>
         </div>
-        <button
-          type="button"
-          className="mage-btn mage-btn--quiet"
-          onClick={signOut}
-        >
-          Sign Out
-        </button>
       </header>
 
-      <div className="mage-grid-2">
-        <div className="mage-stack mage-stack--lg">
+      {loading ? (
+        <p className="mage-preset-list__empty">Loading…</p>
+      ) : (
+        <div className="mage-profile">
+          <button
+            type="button"
+            className="mage-avatar mage-avatar--button"
+            onClick={() => fileInputRef.current?.click()}
+            aria-label="Upload avatar"
+            disabled={uploading}
+          >
+            {profile?.avatar_url ? (
+              <img
+                src={profile.avatar_url}
+                alt=""
+                className="mage-avatar__img"
+              />
+            ) : (
+              <span className="mage-avatar__initial">{initial}</span>
+            )}
+            <span className="mage-avatar__overlay">
+              {uploading ? "Uploading…" : "Change"}
+            </span>
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            hidden
+            onChange={onAvatarFile}
+          />
+
           <div className="mage-identity">
-            <h2 className="mage-identity__name">{username}</h2>
+            {editingName ? (
+              <div className="mage-identity__edit">
+                <input
+                  type="text"
+                  className="mage-input"
+                  value={nameDraft}
+                  onChange={(e) => setNameDraft(e.target.value)}
+                  maxLength={32}
+                  autoFocus
+                />
+                <button
+                  type="button"
+                  className="mage-btn mage-btn--primary"
+                  onClick={saveUsername}
+                  disabled={saving}
+                >
+                  {saving ? "Saving…" : "Save"}
+                </button>
+                <button
+                  type="button"
+                  className="mage-btn mage-btn--quiet"
+                  onClick={() => {
+                    setEditingName(false);
+                    setNameDraft(profile?.username ?? "");
+                    setError(null);
+                  }}
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <div className="mage-identity__row">
+                <h2 className="mage-identity__name">{displayName}</h2>
+                <button
+                  type="button"
+                  className="mage-btn mage-btn--quiet mage-btn--tiny"
+                  onClick={() => setEditingName(true)}
+                >
+                  Edit
+                </button>
+              </div>
+            )}
             <p className="mage-identity__email">{email}</p>
           </div>
-          <div>
-            <p className="mage-eyebrow">
-              <span className="mage-eyebrow__num">{presetCount.toString().padStart(2, "0")}</span>
-              Presets Created
-            </p>
-          </div>
-        </div>
 
-        <div className="mage-stack">
-          <p className="mage-eyebrow">
-            <span className="mage-eyebrow__num">02</span>
-            My Presets
-          </p>
-          {loading ? (
-            <p className="mage-preset-list__empty">Loading…</p>
-          ) : presetCount === 0 ? (
-            <p className="mage-preset-list__empty">
-              No presets yet. Create one from the Player page.
-            </p>
-          ) : (
-            <ul className="mage-preset-list">
-              {presets.map((p, i) => (
-                <li key={p.id}>
-                  <span className="mage-preset-list__num">
-                    {(i + 1).toString().padStart(2, "0")}
-                  </span>
-                  <span>{p.name}</span>
-                </li>
-              ))}
-            </ul>
-          )}
+          <dl className="mage-profile-meta">
+            <div>
+              <dt>Member since</dt>
+              <dd>{memberSince}</dd>
+            </div>
+          </dl>
+
+          {error && <p className="mage-profile__error">{error}</p>}
+
+          <button
+            type="button"
+            className="mage-btn mage-btn--quiet mage-profile__signout"
+            onClick={signOut}
+          >
+            Sign Out
+          </button>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/platform/src/mage-ui.css
+++ b/platform/src/mage-ui.css
@@ -688,3 +688,174 @@
 .mage-audio-picker__name--empty {
   color: var(--mage-cream-40);
 }
+
+/* ---------- profile (no card, just content) ---------- */
+
+.mage-profile {
+  margin-top: clamp(1.5rem, 4vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.75rem;
+  max-width: 520px;
+}
+
+.mage-profile__signout {
+  margin-top: 0.5rem;
+}
+
+.mage-profile__error {
+  margin: 0;
+  color: var(--mage-magenta);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+}
+
+.mage-avatar--button {
+  position: relative;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.mage-avatar--button:hover:not(:disabled) {
+  transform: scale(1.02);
+  box-shadow:
+    0 0 0 1px var(--mage-cream-20),
+    0 0 50px -4px var(--mage-mint-30),
+    inset 0 0 0 6px var(--mage-ink-strong);
+}
+
+.mage-avatar--button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.mage-avatar__img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.mage-avatar__initial {
+  position: relative;
+  z-index: 1;
+}
+
+.mage-avatar__overlay {
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 0.35rem 0;
+  background: rgba(0, 0, 0, 0.55);
+  color: var(--mage-cream);
+  font-size: 0.65rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-align: center;
+  opacity: 0;
+  transition: opacity 160ms ease;
+  z-index: 2;
+}
+
+.mage-avatar--button:hover .mage-avatar__overlay,
+.mage-avatar--button:focus-visible .mage-avatar__overlay,
+.mage-avatar--button:disabled .mage-avatar__overlay {
+  opacity: 1;
+}
+
+.mage-identity__row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.mage-identity__edit {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.mage-input {
+  background: var(--mage-cream-05);
+  border: 1px solid var(--mage-cream-20);
+  border-radius: var(--mage-radius-sm);
+  color: var(--mage-cream);
+  font-family: var(--mage-font-body);
+  font-size: 1rem;
+  padding: 0.55rem 0.8rem;
+  outline: none;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+
+.mage-input:focus {
+  border-color: var(--mage-mint-60);
+  background: var(--mage-cream-10);
+}
+
+.mage-btn--tiny {
+  font-size: 0.65rem !important;
+  padding: 0.3rem 0.65rem !important;
+  letter-spacing: 0.12em;
+}
+
+.mage-avatar {
+  width: 104px;
+  height: 104px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-family: var(--mage-font-display);
+  font-size: 2.75rem;
+  font-weight: 300;
+  color: var(--mage-cream);
+  letter-spacing: 0.02em;
+  background:
+    conic-gradient(
+      from 140deg,
+      var(--mage-mint) 0deg,
+      var(--mage-ice) 120deg,
+      var(--mage-magenta) 240deg,
+      var(--mage-mint) 360deg
+    );
+  box-shadow:
+    0 0 0 1px var(--mage-cream-20),
+    0 0 40px -6px var(--mage-mint-30),
+    inset 0 0 0 6px var(--mage-ink-strong);
+  margin-bottom: 0.25rem;
+  user-select: none;
+}
+
+.mage-profile-meta {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mage-profile-meta > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.mage-profile-meta dt {
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--mage-cream-40);
+}
+
+.mage-profile-meta dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--mage-cream-90);
+}
+


### PR DESCRIPTION
## Summary
- Redesign Profile page as clean, left-aligned content (no card). Removes "Presets Created" + "My Presets" sections.
- Clickable avatar with image upload to Supabase Storage (cache-busted URL so it renders instantly after upload).
- Inline username editing, persisted to the \`profile\` table.
- Member-since date pulled from the auth session.

## Database changes (required before merging)
Run the new migration once in **Supabase Dashboard → SQL Editor**:
\`\`\`
database/profile.sql
\`\`\`
It is **idempotent** — safe to re-run. It will:
1. Create/patch the \`profile\` table (adds \`avatar_url\`, timestamps) with RLS.
2. Add a unique index on \`lower(username)\`.
3. Install an \`auth.users\` trigger so every new signup gets a profile row automatically.
4. Backfill profile rows for existing users.
5. Create the \`avatars\` storage bucket (public read) with per-user write policies (\`<user_id>/...\` path convention).

No manual bucket creation needed — the SQL handles it.

## Frontend changes
- \`platform/src/components/Profile.tsx\` — fetch profile, upload avatar, edit username, display-only fallbacks.
- \`platform/src/mage-ui.css\` — styles for avatar button (hover "Change" overlay), edit row, input, tiny button, error state.

## Validation
- Avatar: 2 MB max, images only, client-side checked.
- RLS enforces users can only write their own row and their own storage folder.

## Test plan
- [ ] Run \`database/profile.sql\` in Supabase SQL Editor
- [ ] Sign in, visit Profile — avatar shows first initial, username shows
- [ ] Click avatar, upload an image — renders immediately, persists on reload
- [ ] Click Edit next to username, change it, Save — persists on reload
- [ ] Try a 3 MB image — error shown, no upload
- [ ] Sign out still works