### PR TITLE
Rewrite EnginePlayer.tsx to use typed mage package (closes #62)

### DIFF
--- a/platform/src/components/Player.tsx
+++ b/platform/src/components/Player.tsx
@@ -7,7 +7,7 @@ import Search from "@search/search-bar-main";
 
 const Player = () => {
   const { session, signOut } = UserAuth();
-  const [preset, setPreset] = useState<any>("");
+  const [preset, setPreset] = useState<string | object | null>(null);
   const [audioSource, setAudioSource] = useState("");
   const [audioFileName, setAudioFileName] = useState("");
   const fileInputRef = useRef<HTMLInputElement | null>(null);

--- a/platform/src/components/mage engine/EnginePlayer.tsx
+++ b/platform/src/components/mage engine/EnginePlayer.tsx
@@ -1,71 +1,55 @@
 import { useEffect, useRef, useState } from "react";
-// @ts-ignore
-import AudioEngine from "@audio/AudioEngine";
-// @ts-ignore
-import AudioController from "@audio/AudioController";
 import LoadingSpinner from "../LoadingSpinner";
 import { initMAGE, type MAGEEngineAPI } from "@notrac/mage";
 import "./engine.css";
 
 type EnginePlayerProps = {
-  preset?: string;
+  preset?: string | object | null;
   displayControls?: boolean;
   audioSource?: string;
 };
 
 const EnginePlayer = ({ displayControls = false, preset, audioSource }: EnginePlayerProps) => {
-  const canvasRef = useRef(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const engineRef = useRef<MAGEEngineAPI | null>(null);
   const [engine, setEngine] = useState<MAGEEngineAPI | null>(null);
-  const [audioController, setAudioController] = useState<any>(null);
   const [audioLoaded, setAudioLoaded] = useState(false);
 
   useEffect(() => {
     if (!canvasRef.current) return;
-    let disposed = false;
-
-    if (disposed || !canvasRef.current) return;
 
     const mageEngine = initMAGE({
       canvas: canvasRef.current,
       withControls: {active: displayControls, integrated: false},
       autoStart: true,
     });
+    engineRef.current = mageEngine;
     setEngine(mageEngine);
 
-    const ae = new AudioEngine();
-    const ac = new AudioController(ae);
-    setAudioController(ac);
-
-    if (audioSource) {
-      mageEngine.loadAudio(audioSource);
-      ac.loadFromUrl(audioSource);
-    }
-
     return () => {
-      disposed = true;
-      if (mageEngine) mageEngine.dispose();
+      engineRef.current = null;
+      mageEngine.dispose();
     };
   }, []);
 
   useEffect(() => {
-    if (audioSource && engine && audioController) {
-      setAudioLoaded(false);
-      engine.loadAudio(audioSource);
-      audioController.loadFromUrl(audioSource);
-      // TODO: Audio bugged right now and doesn't report when loaded
-      setAudioLoaded(true);
-    }
-  }, [audioSource]);
+    if (!engine || !audioSource) return;
+    setAudioLoaded(false);
+    engine.loadAudio(audioSource);
+
+    const intervalId = window.setInterval(() => {
+      if (engine.isAudioLoaded()) {
+        setAudioLoaded(true);
+        window.clearInterval(intervalId);
+      }
+    }, 100);
+
+    return () => window.clearInterval(intervalId);
+  }, [audioSource, engine]);
 
   useEffect(() => {
-    if (preset) loadPreset(preset);
-  }, [preset]);
-
-  const loadPreset = async (preset: any) => {
-    if (!engine) return;
-    engine.loadPreset(preset);
-    if (audioController) audioController.loadPreset(preset);
-  };
+    if (engine && preset) engine.loadPreset(preset as any);
+  }, [preset, engine]);
 
   return (
     <div className="mage-engine">
@@ -85,10 +69,7 @@ const EnginePlayer = ({ displayControls = false, preset, audioSource }: EnginePl
         <button
           type="button"
           className="mage-btn"
-          onClick={() => {
-            engine?.play();
-            audioController?.play();
-          }}
+          onClick={() => engine?.play()}
           disabled={!audioLoaded}
         >
           Play
@@ -96,10 +77,7 @@ const EnginePlayer = ({ displayControls = false, preset, audioSource }: EnginePl
         <button
           type="button"
           className="mage-btn"
-          onClick={() => {
-            engine?.pause?.();
-            audioController?.pause();
-          }}
+          onClick={() => engine?.pause()}
           disabled={!audioLoaded}
         >
           Pause


### PR DESCRIPTION
## Summary
- Remove parallel `AudioEngine` / `AudioController` stack and `@ts-ignore`s; use the engine's own audio methods (`loadAudio`, `play`, `pause`, `isAudioLoaded`).
- `loadAudio` has no completion callback — poll `isAudioLoaded()` every 100ms to flip the `audioLoaded` flag that gates Play/Pause.
- Tighten `preset` typing in `Player.tsx` from `any` to `string | object | null`.

Closes #62.

## Test plan
- [x] `npm run build` passes with zero TS errors
- [ ] `npm run dev` — Player page loads, preset renders, Play/Pause work, no console errors