### PR TITLE
Wire captureThumbnail() into preset save flow (#63)

### DIFF
--- a/database/preset_thumbnails_bucket.sql
+++ b/database/preset_thumbnails_bucket.sql
@@ -1,0 +1,30 @@
+-- Storage bucket for preset thumbnails. Public read, authenticated write.
+-- One file per preset, keyed by preset id: preset-thumbnails/{preset_id}.png
+-- Idempotent: safe to re-run.
+
+insert into storage.buckets (id, name, public)
+values ('preset-thumbnails', 'preset-thumbnails', true)
+on conflict (id) do nothing;
+
+-- Policies: public read, authenticated users can insert/update/delete.
+drop policy if exists "preset_thumbnails_public_read"    on storage.objects;
+drop policy if exists "preset_thumbnails_auth_insert"    on storage.objects;
+drop policy if exists "preset_thumbnails_auth_update"    on storage.objects;
+drop policy if exists "preset_thumbnails_auth_delete"    on storage.objects;
+
+create policy "preset_thumbnails_public_read"
+  on storage.objects for select
+  using (bucket_id = 'preset-thumbnails');
+
+create policy "preset_thumbnails_auth_insert"
+  on storage.objects for insert
+  with check (bucket_id = 'preset-thumbnails' and auth.role() = 'authenticated');
+
+create policy "preset_thumbnails_auth_update"
+  on storage.objects for update
+  using (bucket_id = 'preset-thumbnails' and auth.role() = 'authenticated')
+  with check (bucket_id = 'preset-thumbnails' and auth.role() = 'authenticated');
+
+create policy "preset_thumbnails_auth_delete"
+  on storage.objects for delete
+  using (bucket_id = 'preset-thumbnails' and auth.role() = 'authenticated');

--- a/platform/src/components/MyPresets.tsx
+++ b/platform/src/components/MyPresets.tsx
@@ -68,6 +68,14 @@ const MyPresets = () => {
                 <span className="mage-preset-list__num">
                   {(index + 1).toString().padStart(2, '0')}
                 </span>
+                {p.thumbnail_url && (
+                  <img
+                    src={p.thumbnail_url}
+                    alt={p.name}
+                    className="mage-preset-thumb"
+                    loading="lazy"
+                  />
+                )}
                 <div className="mage-preset-info">
                   <span className="mage-preset-name">{p.name}</span>
                   <span className="mage-tagline">TAG: <strong>{p.tag}</strong></span>

--- a/platform/src/components/Player.tsx
+++ b/platform/src/components/Player.tsx
@@ -2,16 +2,33 @@ import { UserAuth } from "../context/AuthContext";
 import EnginePlayer from "./mage engine/EnginePlayer";
 import PresetPreviews from "./PresetPreviews";
 import { useEffect, useRef, useState } from "react";
+import { supabase } from "../supabaseClient";
+import type { MAGEEngineAPI } from "@notrac/mage";
 // @ts-ignore
 import Search from "@search/search-bar-main";
+
+const THUMBNAIL_BUCKET = "preset-thumbnails";
+
+const dataUrlToBlob = (dataUrl: string): Blob => {
+  const [header, base64] = dataUrl.split(",");
+  const mime = header.match(/data:(.*?);base64/)?.[1] ?? "image/png";
+  const bytes = atob(base64);
+  const buf = new Uint8Array(bytes.length);
+  for (let i = 0; i < bytes.length; i++) buf[i] = bytes.charCodeAt(i);
+  return new Blob([buf], { type: mime });
+};
 
 const Player = () => {
   const { session, signOut } = UserAuth();
   const [preset, setPreset] = useState<string | object | null>(null);
   const [audioSource, setAudioSource] = useState("");
   const [audioFileName, setAudioFileName] = useState("");
+  const [presetName, setPresetName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveMsg, setSaveMsg] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const blobUrlRef = useRef<string | null>(null);
+  const engineRef = useRef<MAGEEngineAPI | null>(null);
 
   useEffect(() => {
     return () => {
@@ -38,6 +55,65 @@ const Player = () => {
 
     setAudioFileName(file.name);
     setAudioSource(blobUrl);
+  };
+
+  const handleSave = async () => {
+    const engine = engineRef.current;
+    const userId = session?.user?.id;
+    if (!engine || !supabase || !userId) {
+      setSaveMsg("Not signed in or engine not ready.");
+      return;
+    }
+    if (!presetName.trim()) {
+      setSaveMsg("Name required.");
+      return;
+    }
+    setSaving(true);
+    setSaveMsg(null);
+    try {
+      const exported = engine.toPreset();
+      const sceneData = JSON.parse(JSON.stringify(exported));
+
+      const { data: inserted, error: insertErr } = await supabase
+        .from("preset")
+        .insert({ user_id: userId, name: presetName.trim(), scene_data: sceneData })
+        .select("id")
+        .single();
+      if (insertErr || !inserted) throw insertErr ?? new Error("Insert failed");
+      const presetId = inserted.id as number;
+
+      const dataUrl = engine.captureThumbnail
+        ? await engine.captureThumbnail(exported)
+        : null;
+      if (dataUrl) {
+        const blob = dataUrlToBlob(dataUrl);
+        const path = `${presetId}.png`;
+        const { error: upErr } = await supabase.storage
+          .from(THUMBNAIL_BUCKET)
+          .upload(path, blob, { upsert: true, contentType: blob.type });
+        if (upErr) throw upErr;
+
+        const { data: urlData } = supabase.storage
+          .from(THUMBNAIL_BUCKET)
+          .getPublicUrl(path);
+        const publicUrl = urlData?.publicUrl;
+        if (publicUrl) {
+          const { error: updErr } = await supabase
+            .from("preset")
+            .update({ thumbnail_url: publicUrl })
+            .eq("id", presetId);
+          if (updErr) throw updErr;
+        }
+      }
+
+      setPresetName("");
+      setSaveMsg(`Saved "${presetName.trim()}".`);
+    } catch (err) {
+      console.error("Save preset failed:", err);
+      setSaveMsg(err instanceof Error ? err.message : "Save failed.");
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
@@ -103,7 +179,37 @@ const Player = () => {
               <span className="mage-eyebrow__num">02</span>
               Output
             </p>
-            <EnginePlayer preset={preset} audioSource={audioSource} />
+            <EnginePlayer
+              preset={preset}
+              audioSource={audioSource}
+              onEngineReady={(e) => (engineRef.current = e)}
+            />
+          </div>
+
+          <div className="mage-stack">
+            <p className="mage-eyebrow">
+              <span className="mage-eyebrow__num">04</span>
+              Save Preset
+            </p>
+            <div className="mage-save-row">
+              <input
+                type="text"
+                className="mage-input"
+                placeholder="Preset name"
+                value={presetName}
+                onChange={(e) => setPresetName(e.target.value)}
+                disabled={saving}
+              />
+              <button
+                type="button"
+                className="mage-btn"
+                onClick={handleSave}
+                disabled={saving || !session?.user?.id}
+              >
+                {saving ? "Saving…" : "Save"}
+              </button>
+            </div>
+            {saveMsg && <p className="mage-save-msg">{saveMsg}</p>}
           </div>
         </div>
 

--- a/platform/src/components/mage engine/EnginePlayer.tsx
+++ b/platform/src/components/mage engine/EnginePlayer.tsx
@@ -7,11 +7,11 @@ type EnginePlayerProps = {
   preset?: string | object | null;
   displayControls?: boolean;
   audioSource?: string;
+  onEngineReady?: (engine: MAGEEngineAPI) => void;
 };
 
-const EnginePlayer = ({ displayControls = false, preset, audioSource }: EnginePlayerProps) => {
+const EnginePlayer = ({ displayControls = false, preset, audioSource, onEngineReady }: EnginePlayerProps) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const engineRef = useRef<MAGEEngineAPI | null>(null);
   const [engine, setEngine] = useState<MAGEEngineAPI | null>(null);
   const [audioLoaded, setAudioLoaded] = useState(false);
 
@@ -20,14 +20,13 @@ const EnginePlayer = ({ displayControls = false, preset, audioSource }: EnginePl
 
     const mageEngine = initMAGE({
       canvas: canvasRef.current,
-      withControls: {active: displayControls, integrated: false},
+      withControls: { active: displayControls, integrated: false },
       autoStart: true,
     });
-    engineRef.current = mageEngine;
     setEngine(mageEngine);
+    onEngineReady?.(mageEngine);
 
     return () => {
-      engineRef.current = null;
       mageEngine.dispose();
     };
   }, []);

--- a/platform/src/mage-ui.css
+++ b/platform/src/mage-ui.css
@@ -799,6 +799,31 @@
   background: var(--mage-cream-10);
 }
 
+.mage-save-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.mage-save-row .mage-input {
+  flex: 1;
+}
+
+.mage-save-msg {
+  margin-top: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--mage-cream-60, var(--mage-cream));
+}
+
+.mage-preset-thumb {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: var(--mage-radius-sm);
+  margin-right: 0.6rem;
+  background: var(--mage-cream-05);
+}
+
 .mage-btn--tiny {
   font-size: 0.65rem !important;
   padding: 0.3rem 0.65rem !important;


### PR DESCRIPTION
## Summary
- New "Save Preset" UI on the Player page (no save flow existed prior).
- On save: insert row → `engine.captureThumbnail(preset)` → upload to Supabase `preset-thumbnails` bucket → write public URL to `preset.thumbnail_url`.
- `MyPresets` grid renders the stored thumbnail when present.
- Adds `database/preset_thumbnails_bucket.sql` for the bucket + RLS policies (public read, authenticated write).

Refs #63.

## Notes
- `thumbnail_url` column already existed on `preset` (no schema migration needed).
- `captureThumbnail` returns `Promise<string | null>` (data URL). Save succeeds even if capture returns null — thumbnail is a best-effort enrichment.
- Filename scheme: `{preset_id}.png`, upsert on save (per issue spec).

## Test plan
- [x] `npm run build` passes with zero TS errors
- [ ] Run `preset_thumbnails_bucket.sql` in Supabase
- [ ] Create a new preset in Player → confirm file appears in bucket
- [ ] Confirm `preset.thumbnail_url` populated
- [ ] Confirm `MyPresets` renders the thumbnail
- [ ] No console errors during save