### PR TITLE
Remove stale 'TAG:' row from MyPresets grid

### DIFF
--- a/platform/src/components/MyPresets.tsx
+++ b/platform/src/components/MyPresets.tsx
@@ -78,7 +78,6 @@ const MyPresets = () => {
                 )}
                 <div className="mage-preset-info">
                   <span className="mage-preset-name">{p.name}</span>
-                  <span className="mage-tagline">TAG: <strong>{p.tag}</strong></span>
                 </div>
                 <button 
                   className="mage-btn mage-btn--quiet delete-action" 


### PR DESCRIPTION
The preset table has no `tag` column, so the grid was rendering `TAG:` followed by `undefined`. Removing the row.